### PR TITLE
Make compatible with Symfony v3. Fix #6

### DIFF
--- a/src/Dflydev/DotAccessConfiguration/YamlFileConfigurationBuilder.php
+++ b/src/Dflydev/DotAccessConfiguration/YamlFileConfigurationBuilder.php
@@ -42,7 +42,7 @@ class YamlFileConfigurationBuilder extends AbstractConfigurationBuilder
         $imports = array();
         foreach ($this->yamlConfigurationFilenames as $yamlConfigurationFilename) {
             if (file_exists($yamlConfigurationFilename)) {
-                $config = DotAccessDataUtil::mergeAssocArray($config, Yaml::parse($yamlConfigurationFilename));
+                $config = DotAccessDataUtil::mergeAssocArray($config, Yaml::parse(file_get_contents($yamlConfigurationFilename)));
                 if (isset($config['imports'])) {
                     foreach ((array) $config['imports'] as $file) {
                         if (0 === strpos($file, '/')) {


### PR DESCRIPTION
Fix issue #6 

```
PHP Catchable fatal error:  Argument 1 passed to Dflydev\DotAccessData\Data::import() 
must be of the type array, string given, called in 
vendor/dflydev/dot-access-configuration/src/Dflydev/DotAccessConfiguration/AbstractConfiguration.php 
on line 105 and defined in 
vendor/dflydev/dot-access-data/src/Dflydev/DotAccessData/Data.php 
on line 178
```

* Use `file_get_contents` to load content and pass to `Yaml::parse` method.