### PR TITLE
Resolve Symfony 4 deprecation notice

### DIFF
--- a/src/Dflydev/DotAccessConfiguration/YamlConfigurationBuilder.php
+++ b/src/Dflydev/DotAccessConfiguration/YamlConfigurationBuilder.php
@@ -40,7 +40,7 @@ class YamlConfigurationBuilder extends AbstractConfigurationBuilder
     {
         if (null !== $this->input) {
             try{
-                $yml = Yaml::parse($this->input, true);
+                $yml = Yaml::parse($this->input, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
             } catch (\Exception $e) {
                 throw new InvalidArgumentException($e->getMessage(), 0, $e);
             }


### PR DESCRIPTION
Passing "true" here is going away in Symfony 4.x, so this flag is recommended instead.