### PR TITLE
Adding PHPUnit as dev dependency

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**. We accept contributions via Pull Requests on [GitHub](https://github.com/dflydev/dflydev-dot-access-configuration).
+
+## Pull Requests
+
+- **[PSR-12 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md)** - The easiest way to apply the conventions is to run `./vendor/bin/phpcbf`.
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Tests must pass** - All automated tests, including things like code style checks, but be passing before we'll consider merging the change.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](https://semver.org/). Randomly breaking public APIs is not an option.
+
+- **Create feature branches** - Don't ask us to pull from your default branch.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
+
+
+## Running Tests
+
+``` bash
+$ composer test
+```
+
+
+**Happy coding**!

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+    push: ~
+    pull_request: ~
+
+jobs:
+
+    phpunit:
+        name: PHPUnit on ${{ matrix.php }} ${{ matrix.composer-flags }}
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php: ['7.4', '8.0', '8.1']
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                fetch-depth: 1
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: curl
+                  coverage: pcov
+
+            - name: Install Composer dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                  composer-options: "--no-progress --prefer-dist --optimize-autoloader"
+
+            - name: Configure matchers
+              uses: mheap/phpunit-matcher-action@v1
+
+            - name: PHPUnit
+              run: ./vendor/bin/phpunit --coverage-text --teamcity

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.phpunit.result.cache
 composer.lock
 vendor

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,13 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=7.4",
         "dflydev/dot-access-data": "1.*",
         "dflydev/placeholder-resolver": "1.*"
     },
     "require-dev": {
-        "symfony/yaml": "~2.1"
+        "symfony/yaml": "^5.4 || ^6.0",
+        "phpunit/phpunit": "^9.3"
     },
     "suggest": {
         "symfony/yaml": "Required for using the YAML Configuration Builders"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="tests/bootstrap.php">
-    <testsuites>
-        <testsuite name="Dot Access Configuration Test Suite">
-            <directory>./tests/Dflydev/DotAccessConfiguration</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/Dflydev/DotAccessConfiguration/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./src/Dflydev/DotAccessConfiguration/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Dot Access Configuration Test Suite">
+      <directory>./tests/Dflydev/DotAccessConfiguration</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Dflydev/DotAccessConfiguration/AbstractConfigurationBuilderTest.php
+++ b/tests/Dflydev/DotAccessConfiguration/AbstractConfigurationBuilderTest.php
@@ -11,24 +11,25 @@
 
 namespace Dflydev\DotAccessConfiguration;
 
-class AbstractConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractConfigurationBuilderTest extends TestCase
 {
     public function testPlaceholderResolver()
     {
-        $placeholderResolver = $this->getMock('Dflydev\PlaceholderResolver\PlaceholderResolverInterface');
+        $placeholderResolver = $this->getMockBuilder(\Dflydev\PlaceholderResolver\PlaceholderResolverInterface::class)->getMock();
 
-        $placeholderResolverFactory = $this->getMock('Dflydev\DotAccessConfiguration\PlaceholderResolverFactoryInterface');
+        $placeholderResolverFactory = $this->getMockBuilder(\Dflydev\DotAccessConfiguration\PlaceholderResolverFactoryInterface::class)->getMock();
         $placeholderResolverFactory
             ->expects($this->once())
             ->method('create')
             ->will($this->returnValue($placeholderResolver))
         ;
 
-        $configurationBuilder = $this->getMockForAbstractClass('Dflydev\DotAccessConfiguration\AbstractConfigurationBuilder');
+        $configurationBuilder = $this->getMockForAbstractClass(\Dflydev\DotAccessConfiguration\AbstractConfigurationBuilder::class);
         $configurationBuilder
             ->expects($this->once())
-            ->method('internalBuild')
-        ;
+            ->method('internalBuild');
 
         $configurationBuilder->setPlaceholderResolverFactory($placeholderResolverFactory);
         $configurationBuilder->build();
@@ -36,7 +37,7 @@ class AbstractConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testReconfigure()
     {
-        $configuration000 = $this->getMock('Dflydev\DotAccessConfiguration\ConfigurationInterface');
+        $configuration000 = $this->getMockBuilder(\Dflydev\DotAccessConfiguration\ConfigurationInterface::class)->getMock();
 
         $configuration000
             ->expects($this->exactly(2))
@@ -45,7 +46,7 @@ class AbstractConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('FOO'))
         ;
 
-        $configuration001 = $this->getMock('Dflydev\DotAccessConfiguration\ConfigurationInterface');
+        $configuration001 = $this->getMockBuilder(\Dflydev\DotAccessConfiguration\ConfigurationInterface::class)->getMock();
 
         $configuration001
             ->expects($this->exactly(2))
@@ -54,16 +55,16 @@ class AbstractConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('BAR'))
         ;
 
-        $placeholderResolver = $this->getMock('Dflydev\PlaceholderResolver\PlaceholderResolverInterface');
+        $placeholderResolver = $this->getMockBuilder(\Dflydev\PlaceholderResolver\PlaceholderResolverInterface::class)->getMock();
 
-        $placeholderResolverFactory = $this->getMock('Dflydev\DotAccessConfiguration\PlaceholderResolverFactoryInterface');
+        $placeholderResolverFactory = $this->getMockBuilder(\Dflydev\DotAccessConfiguration\PlaceholderResolverFactoryInterface::class)->getMock();
         $placeholderResolverFactory
             ->expects($this->exactly(2))
             ->method('create')
             ->will($this->returnValue($placeholderResolver))
         ;
 
-        $configurationFactory = $this->getMock('Dflydev\DotAccessConfiguration\ConfigurationFactoryInterface');
+        $configurationFactory = $this->getMockBuilder(\Dflydev\DotAccessConfiguration\ConfigurationFactoryInterface::class)->getMock();
         $configurationFactory
             ->expects($this->exactly(2))
             ->method('create')

--- a/tests/Dflydev/DotAccessConfiguration/ConfigurationDataSourceTest.php
+++ b/tests/Dflydev/DotAccessConfiguration/ConfigurationDataSourceTest.php
@@ -11,11 +11,13 @@
 
 namespace Dflydev\DotAccessConfiguration;
 
-class ConfigurationDataSourceTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationDataSourceTest extends TestCase
 {
     public function test()
     {
-        $configuration = $this->getMock('Dflydev\DotAccessConfiguration\Configuration');
+        $configuration = $this->getMockBuilder(\Dflydev\DotAccessConfiguration\Configuration::class)->getMock();
 
         $configuration
             ->expects($this->any())

--- a/tests/Dflydev/DotAccessConfiguration/ConfigurationFactoryTest.php
+++ b/tests/Dflydev/DotAccessConfiguration/ConfigurationFactoryTest.php
@@ -11,11 +11,15 @@
 
 namespace Dflydev\DotAccessConfiguration;
 
-class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationFactoryTest extends TestCase
 {
     public function testCreate()
     {
         $configurationFactory = new ConfigurationFactory;
         $configuration = $configurationFactory->create();
+
+        $this->assertNotNull($configuration);
     }
 }

--- a/tests/Dflydev/DotAccessConfiguration/ConfigurationTest.php
+++ b/tests/Dflydev/DotAccessConfiguration/ConfigurationTest.php
@@ -11,7 +11,9 @@
 
 namespace Dflydev\DotAccessConfiguration;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
 {
     protected function getTestData()
     {
@@ -148,7 +150,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPlaceholderResolver()
     {
-        $placeholderResolver = $this->getMock('Dflydev\PlaceholderResolver\PlaceholderResolverInterface');
+        $placeholderResolver = $this->getMockBuilder(\Dflydev\PlaceholderResolver\PlaceholderResolverInterface::class)->getMock();
 
         $placeholderResolver
             ->expects($this->once())

--- a/tests/Dflydev/DotAccessConfiguration/PlaceholderResolverFactoryTest.php
+++ b/tests/Dflydev/DotAccessConfiguration/PlaceholderResolverFactoryTest.php
@@ -11,12 +11,16 @@
 
 namespace Dflydev\DotAccessConfiguration;
 
-class PlaceholderResolverFactoryTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PlaceholderResolverFactoryTest extends TestCase
 {
     public function testCreate()
     {
-        $configuration = $this->getMock('Dflydev\DotAccessConfiguration\Configuration');
+        $configuration = $this->getMockBuilder(\Dflydev\DotAccessConfiguration\Configuration::class)->getMock();
         $placeholderResolverFactory = new PlaceholderResolverFactory;
         $placeholderResolver = $placeholderResolverFactory->create($configuration);
+
+        $this->assertNotNull($placeholderResolver);
     }
 }

--- a/tests/Dflydev/DotAccessConfiguration/YamlConfigurationBuilderTest.php
+++ b/tests/Dflydev/DotAccessConfiguration/YamlConfigurationBuilderTest.php
@@ -11,24 +11,32 @@
 
 namespace Dflydev\DotAccessConfiguration;
 
-class YamlConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class YamlConfigurationBuilderTest extends TestCase
 {
-    public function setUp()
+    public function testBuild()
     {
         if (!class_exists('Symfony\Component\Yaml\Yaml')) {
             $this->markTestSkipped('The Symfony2 YAML library is not available');
         }
-    }
 
-    public function testBuild()
-    {
         $configurationBuilder = new YamlConfigurationBuilder;
         $configuration = $configurationBuilder->build();
+
+        $this->assertNotNull($configuration);
+
     }
 
     public function testBuildWithData()
     {
+        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
+            $this->markTestSkipped('The Symfony2 YAML library is not available');
+        }
+
         $configurationBuilder = new YamlConfigurationBuilder('foo: bar');
         $configuration = $configurationBuilder->build();
+
+        $this->assertNotNull($configuration);
     }
 }

--- a/tests/Dflydev/DotAccessConfiguration/YamlFileConfigurationBuilderTest.php
+++ b/tests/Dflydev/DotAccessConfiguration/YamlFileConfigurationBuilderTest.php
@@ -11,17 +11,17 @@
 
 namespace Dflydev\DotAccessConfiguration;
 
-class YamlFileConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class YamlFileConfigurationBuilderTest extends TestCase
 {
-    public function setUp()
+    public function testBuilder()
     {
+
         if (!class_exists('Symfony\Component\Yaml\Yaml')) {
             $this->markTestSkipped('The Symfony2 YAML library is not available');
         }
-    }
 
-    public function testBuilder()
-    {
         $configurationBuilder = new YamlFileConfigurationBuilder(array(__DIR__.'/fixtures/yamlFileConfigurationBuilderTest-testBuilder.yml'));
 
         $configuration = $configurationBuilder->build();


### PR DESCRIPTION
And update the tests to use the new phpunit version

- update the tests which has no assertions
- drop older php versions `7.1, 7.2 and 7.3`
- upgrade symfony/yaml
- update to use the latest version of checkout action

I kept PHP `7.4` to give people a chance to upgrade before requiring PHP 8.x